### PR TITLE
Cancel text : Chinese -> English

### DIFF
--- a/demo/src/pages/Editor/components/useEmailModal.tsx
+++ b/demo/src/pages/Editor/components/useEmailModal.tsx
@@ -94,6 +94,7 @@ export function useEmailModal() {
             style={{ zIndex: 9999 }}
             title='Send test email'
             okText='Send'
+            cancelText='Cancel'
             visible={visible}
             confirmLoading={emailSendLoading}
             onOk={() => handleSubmit()}

--- a/demo/src/pages/Editor/components/useMergeTagsModal.tsx
+++ b/demo/src/pages/Editor/components/useMergeTagsModal.tsx
@@ -45,6 +45,7 @@ export function useMergeTagsModal(defaultMergeTags: Record<string, any>) {
             style={{ zIndex: 9999, width: '80vw', height: '80vh' }}
             title='Merge tags'
             okText='Save'
+            cancelText='Cancel'
             visible={visible}
             onOk={() => handleSubmit()}
             onCancel={closeModal}


### PR DESCRIPTION
The 'Update mergeTags' and 'Send test email' had cancel buttons in chinese (取消). Changed these to English. 

![image](https://user-images.githubusercontent.com/43818888/177329364-abf769d1-1879-4755-97ff-3a805b6bf1ab.png)
![image](https://user-images.githubusercontent.com/43818888/177330433-e72c296b-38ce-4bba-801e-6ab4a9a2b467.png)

